### PR TITLE
obey safe_repr settings for exceptions

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -630,7 +630,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
             'frames': frames,
             'exception': {
                 'class': cls.__name__,
-                'message': text(exc),
+                'message': _transform(exc),
             }
         }
     }

--- a/rollbar/test/contrib/flask/test_flask.py
+++ b/rollbar/test/contrib/flask/test_flask.py
@@ -87,7 +87,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
+            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],
@@ -115,7 +115,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
+            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -127,7 +127,7 @@ class RollbarTest(BaseTest):
         self.assertIn('body', payload['data'])
         self.assertIn('trace', payload['data']['body'])
         self.assertIn('exception', payload['data']['body']['trace'])
-        self.assertEqual(payload['data']['body']['trace']['exception']['message'], "<type 'exceptions.Exception'>")
+        self.assertEqual(payload['data']['body']['trace']['exception']['message'], str(type(Exception())))
         self.assertEqual(payload['data']['body']['trace']['exception']['class'], 'Exception')
 
         self.assertNotIn('args', payload['data']['body']['trace']['frames'][-1])

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -127,7 +127,7 @@ class RollbarTest(BaseTest):
         self.assertIn('body', payload['data'])
         self.assertIn('trace', payload['data']['body'])
         self.assertIn('exception', payload['data']['body']['trace'])
-        self.assertEqual(payload['data']['body']['trace']['exception']['message'], 'foo')
+        self.assertEqual(payload['data']['body']['trace']['exception']['message'], "<type 'exceptions.Exception'>")
         self.assertEqual(payload['data']['body']['trace']['exception']['class'], 'Exception')
 
         self.assertNotIn('args', payload['data']['body']['trace']['frames'][-1])
@@ -743,20 +743,6 @@ class RollbarTest(BaseTest):
         called_with_frame = frames[1]
 
         self.assertEqual('changed', called_with_frame['args'][0])
-
-    @mock.patch('rollbar.send_payload')
-    def test_unicode_exc_info(self, send_payload):
-        message = '\u221a'
-
-        try:
-            raise Exception(message)
-        except:
-            rollbar.report_exc_info()
-
-        self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
-        self.assertEqual(payload['data']['body']['trace']['exception']['message'], message)
-
 
     @mock.patch('requests.post', side_effect=lambda *args, **kw: MockResponse({'status': 'OK'}, 200))
     def test_serialize_and_send_payload(self, post=None):


### PR DESCRIPTION
otherwise they can leak sensitive information